### PR TITLE
HostDataSSLCert#serial type too small

### DIFF
--- a/src/shodan/parsers/host_services/ssl.cr
+++ b/src/shodan/parsers/host_services/ssl.cr
@@ -68,7 +68,7 @@ module Shodan
     property version : Int32?
     property extensions : Array(HostDataSSLExtensions)?
     property fingerprint : Hash(String, String)?
-    property serial : Int64?
+    property serial : UInt128?
     property subject : HostDataSslSubject
     property issuer : HostDataSslIssuer
   end

--- a/src/shodan/parsers/host_services/ssl.cr
+++ b/src/shodan/parsers/host_services/ssl.cr
@@ -68,7 +68,12 @@ module Shodan
     property version : Int32?
     property extensions : Array(HostDataSSLExtensions)?
     property fingerprint : Hash(String, String)?
-    property serial : UInt128?
+    
+    # property serial : UInt128?
+    # changed to the below as there are certs with larger serial numbers than an UInt128 supports
+    @[JSON::Field(converter: String::RawConverter)]
+    property serial : String?
+    
     property subject : HostDataSslSubject
     property issuer : HostDataSslIssuer
   end


### PR DESCRIPTION
Change HostDataSSLCert#serial type from UInt64? to  UInt128?. 

This supports bigger serial numbers and fixes parsing issues with numbers larger than an Int64 supports. This wont fully fix the parsing issue but will allow for more support without breaking int comparisons. 

a more complete parsing fix could be implemented by converting to a string using the following: 
```crystal
    @[JSON::Field(converter: String::RawConverter)]
    property serial : String?
```

